### PR TITLE
Fix restore script when db is empty

### DIFF
--- a/mysql/scripts/database-restore.sh
+++ b/mysql/scripts/database-restore.sh
@@ -41,12 +41,7 @@ if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
     # Connection string which will be used to perform operations on the MySQL database.
     CONNECTION_STRING="mysql --host=$MYSQL_HOSTNAME --port=$MYSQL_PORT --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD $MYSQL_DATABASE"
 
-    TABLES=$($CONNECTION_STRING -e 'show tables' | awk '{ print $1}' | grep -v '^Tables' )
-
-    if [ "$TABLES" == "" ]
-    then
-        fatal "Error - No tables found in $MYSQL_DATABASE database!"
-    fi
+    TABLES=$($CONNECTION_STRING -e 'show tables' | awk '{ print $1}' | grep -v '^Tables' || true )
     
     for table in $TABLES
     do


### PR DESCRIPTION
There was a bug where restore would not work when the db was empty. This was due to grep returning an error code and bombing the rest of the script.

Example output now:

Empty db:
```
root@9afeebf3d732:data # MYSQL_HOSTNAME=db MYSQL_PORT=3306 MYSQL_USERNAME=drupal MYSQL_PASSWORD=drupal MYSQL_DATABASE=local ./database-restore.sh ./master.sql
[INFO]  Restoring Database: ./master.sql
[INFO]  Restore Complete
```

Populated db:
```
root@9afeebf3d732:data # MYSQL_HOSTNAME=db MYSQL_PORT=3306 MYSQL_USERNAME=drupal MYSQL_PASSWORD=drupal MYSQL_DATABASE=local ./database-restore.sh ./master.sql
[INFO]  Deleting local/block_content
[INFO]  Deleting local/block_content__body
[INFO]  Deleting local/block_content_field_data
[INFO]  Deleting local/block_content_field_revision
[INFO]  Deleting local/block_content_revision
[INFO]  Deleting local/block_content_revision__body
[INFO]  Deleting local/cache_bootstrap
[INFO]  Deleting local/cache_config
...
....
[INFO]  Deleting local/users
[INFO]  Deleting local/users_data
[INFO]  Deleting local/users_field_data
[INFO]  Restoring Database: ./master.sql
[INFO]  Restore Complete
```