### PR TITLE
Add globbing support to "where" dump configuration.

### DIFF
--- a/dump/README.md
+++ b/dump/README.md
@@ -24,6 +24,9 @@ where:
   # Only include body field data for current revisions.
   node_revision__body: |-
       revision_id IN (SELECT vid FROM node)
+  # Use globbing on where config.
+  media_revision__*: |-
+    revision_id IN (SELECT vid FROM media)
 
 nodata:
   - cache*

--- a/dump/pkg/config/config_test.go
+++ b/dump/pkg/config/config_test.go
@@ -39,7 +39,7 @@ func TestLoad(t *testing.T) {
 			Rules{
 				Rewrite: map[string]Rewrite{
 					"accounts": map[string]string{
-						"email": "concat(id, \"@sanitized\")",
+						"email":    "concat(id, \"@sanitized\")",
 						"password": "\"SANITIZED_PASSWORD\"",
 					},
 				},
@@ -51,6 +51,7 @@ func TestLoad(t *testing.T) {
 			Rules{
 				Where: map[string]string{
 					"some_table": "revision_id IN (SELECT revision_id FROM another_table)",
+					"fred_*":     "plugh >= 1000",
 				},
 			},
 		},
@@ -66,7 +67,8 @@ func TestLoad(t *testing.T) {
 					},
 				},
 				Where: map[string]string{
-					"corge": "grault IN (SELECT garply FROM waldo)",
+					"corge":  "grault IN (SELECT garply FROM waldo)",
+					"fred_*": "plugh >= 1000",
 				},
 			},
 		},

--- a/dump/pkg/config/test-data/mixed.yml
+++ b/dump/pkg/config/test-data/mixed.yml
@@ -8,3 +8,5 @@ rewrite:
 where:
   corge: |-
     grault IN (SELECT garply FROM waldo)
+  fred_*: |-
+    plugh >= 1000

--- a/dump/pkg/config/test-data/where.yml
+++ b/dump/pkg/config/test-data/where.yml
@@ -1,3 +1,5 @@
 where:
   some_table: |-
     revision_id IN (SELECT revision_id FROM another_table)
+  fred_*: |-
+    plugh >= 1000


### PR DESCRIPTION
## Motivation

I was searching for a way to consistently exclude unpublished revision field data from a Drupal database. Originally this was a script that dynamically generated the `mtk-dump` config file for a specific project.

In the search for a consistent approach I decided to look at adding glob support to the `where` config in the dump package.

So now I'm able to have a single `mtk-dump.conf` file for all my Drupal projects that looks something like this:

```yaml
where:
  # Blocks
  block_content_revision: |-
    revision_id IN (SELECT revision_id FROM block_content)
  block_content_field_revision: |-
    revision_id IN (SELECT revision_id FROM block_content)
  block_content_revision__*: |-
    revision_id IN (SELECT revision_id FROM block_content)
  # Media
  media_revision: |-
    vid IN (SELECT vid FROM media)
  media_field_revision: |-
    vid IN (SELECT vid FROM media)
  media_revision__*: |-
    revision_id IN (SELECT vid FROM media)
  # Nodes
  node_revision: |-
    vid IN (SELECT vid FROM node)
  node_field_revision: |-
    vid IN (SELECT vid FROM node)
  node_revision__*: |-
    revision_id IN (SELECT vid FROM node)
  # Paragraphs
  paragraphs_item_revision: |-
    revision_id IN (SELECT revision_id FROM paragraphs_item)
  paragraphs_item_revision_field_data: |-
    revision_id IN (SELECT revision_id FROM paragraphs_item)
  paragraph_revision__*: |-
    revision_id IN (SELECT revision_id FROM paragraphs_item)
```

## Changes

- Adds glob support to `where` config.
- Updates tests
- Adds example to README.