### PR TITLE
Cache 'SHOW FULL TABLES'

### DIFF
--- a/internal/mysql/mysql.go
+++ b/internal/mysql/mysql.go
@@ -49,6 +49,8 @@ func (o Connection) Open(database string) (*sql.DB, error) {
 type Client struct {
 	DB     *sql.DB
 	Logger *log.Logger
+	// A field for caching a list of tables for this database.
+	cachedTables []string
 }
 
 // NewClient for dumping a full or single table from a database.

--- a/internal/mysql/tables.go
+++ b/internal/mysql/tables.go
@@ -34,6 +34,11 @@ func (d *Client) ListTablesByGlob(globs []string) ([]string, error) {
 
 // QueryTables will return a list of tables.
 func (d *Client) QueryTables() ([]string, error) {
+	// Use the cached tables if we have them.
+	if len(d.cachedTables) > 0 {
+		return d.cachedTables, nil
+	}
+
 	tables := make([]string, 0)
 
 	rows, err := d.DB.Query("SHOW FULL TABLES")
@@ -55,6 +60,9 @@ func (d *Client) QueryTables() ([]string, error) {
 			tables = append(tables, tableName)
 		}
 	}
+
+	// Set the cached tables for future executions.
+	d.cachedTables = tables
 
 	return tables, nil
 }


### PR DESCRIPTION
**Problem**

The number of "SHOW FULL TABLES" executions grows with the more rules that are added.

This causes extra load on the database server.

**Solution**

Cache it!