### PR TITLE
[DDS-132] fix: set character encoding when importing file from csv in s3

### DIFF
--- a/internal/mysql/provider/rds/provider.go
+++ b/internal/mysql/provider/rds/provider.go
@@ -67,8 +67,8 @@ func (d *Client) GetLoadQueryForTable(table string) (string, error) {
 		return "", fmt.Errorf("error: region is not configured correctly")
 	}
 	path := strings.TrimPrefix(d.URI, "s3://")
-	query := fmt.Sprintf("LOAD DATA FROM S3 MANIFEST 'S3-%s://%s/%s.csv.manifest' INTO TABLE `%s`", d.Region, path, table, table)
-	query = fmt.Sprintf("%s FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\n' CHARACTER SET utf8mb4", query)
+	query := fmt.Sprintf("LOAD DATA FROM S3 MANIFEST 'S3-%s://%s/%s.csv.manifest' INTO TABLE `%s` CHARACTER SET utf8mb4", d.Region, path, table, table)
+	query = fmt.Sprintf("%s FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\n'", query)
 
 	return query, nil
 }

--- a/internal/mysql/provider/rds/provider.go
+++ b/internal/mysql/provider/rds/provider.go
@@ -68,7 +68,7 @@ func (d *Client) GetLoadQueryForTable(table string) (string, error) {
 	}
 	path := strings.TrimPrefix(d.URI, "s3://")
 	query := fmt.Sprintf("LOAD DATA FROM S3 MANIFEST 'S3-%s://%s/%s.csv.manifest' INTO TABLE `%s`", d.Region, path, table, table)
-	query = fmt.Sprintf("%s FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\n'", query)
+	query = fmt.Sprintf("%s FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\n' CHARACTER SET utf8mb4", query)
 
 	return query, nil
 }

--- a/internal/mysql/provider/rds/provider_test.go
+++ b/internal/mysql/provider/rds/provider_test.go
@@ -30,6 +30,6 @@ func TestMySQLGetLoadQueryFor(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "ap-southeast-4", "s3://path/to/bucket")
 	query, err := dumper.GetLoadQueryForTable("table_name")
 	assert.Nil(t, err)
-	assert.Equal(t, "LOAD DATA FROM S3 MANIFEST 'S3-ap-southeast-4://path/to/bucket/table_name.csv.manifest' INTO TABLE `table_name` FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\n'", query)
+	assert.Equal(t, "LOAD DATA FROM S3 MANIFEST 'S3-ap-southeast-4://path/to/bucket/table_name.csv.manifest' INTO TABLE `table_name` FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\n' CHARACTER SET utf8mb4", query)
 
 }

--- a/internal/mysql/provider/rds/provider_test.go
+++ b/internal/mysql/provider/rds/provider_test.go
@@ -30,6 +30,5 @@ func TestMySQLGetLoadQueryFor(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "ap-southeast-4", "s3://path/to/bucket")
 	query, err := dumper.GetLoadQueryForTable("table_name")
 	assert.Nil(t, err)
-	assert.Equal(t, "LOAD DATA FROM S3 MANIFEST 'S3-ap-southeast-4://path/to/bucket/table_name.csv.manifest' INTO TABLE `table_name` FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\n' CHARACTER SET utf8mb4", query)
-
+	assert.Equal(t, "LOAD DATA FROM S3 MANIFEST 'S3-ap-southeast-4://path/to/bucket/table_name.csv.manifest' INTO TABLE `table_name` CHARACTER SET utf8mb4 FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\\n'", query)
 }


### PR DESCRIPTION
### The problem:
When importing the database, the character encoding is assumed wrong at some point in the import process for the files and causing invalid characters to pop up in the database. 

### The Solution:
Explicitly set the encoding to `utf8mb4` for the CSV files when referencing them in the SQL files using the `LOAD DATA FROM S3 MANIFEST` files.
