### PR TITLE
Fix string types

### DIFF
--- a/internal/mysql/tables.go
+++ b/internal/mysql/tables.go
@@ -84,6 +84,9 @@ func (d *Client) getProviderClient() (provider.Interface, error) {
 }
 
 // Helper function to get all data for a table.
+// *sql.Rows:	Rows
+// []string:	Columns
+// error:	Error
 func (d *Client) selectAllDataForTable(table string, params provider.DumpParams) (*sql.Rows, []string, error) {
 
 	client, err := d.getProviderClient()

--- a/internal/mysql/utils.go
+++ b/internal/mysql/utils.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"database/sql"
 
 	"github.com/asaskevich/govalidator"
 )
 
-func getValue(raw string, theColumnType ColumnType) (string, error) {
+func getValue(raw string, columnType string) (string, error) {
 	if raw == "" {
 		return "''", nil
 	}
@@ -28,7 +27,7 @@ func getValue(raw string, theColumnType ColumnType) (string, error) {
 		"BIT", "BOOL" }
 
 	// Only want to do this for numeric field types; it can cause problems when done for strings and JSON
-	if slices.Contains(asNumber, theColumnType.DatabaseTypeName) {
+	if slices.Contains(asNumber, columnType) {
 		if govalidator.IsInt(raw) {
 			return escaped, nil
 		}

--- a/internal/mysql/utils.go
+++ b/internal/mysql/utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/asaskevich/govalidator"
 )
 
-func getValue(raw string) (string, error) {
+func getValue(raw string, column_type ColumnType) (string, error) {
 	if raw == "" {
 		return "''", nil
 	}
@@ -18,8 +18,19 @@ func getValue(raw string) (string, error) {
 		return "", err
 	}
 
-	if govalidator.IsInt(raw) {
-		return escaped, nil
+	// List of types from https://dev.mysql.com/doc/refman/8.4/en/data-types.html (just the Numeric ones)
+	asNumber := []string{
+		"INTEGER", "INT", "SMALLINT", "TINYINT", "MEDIUMINT", "BIGINT",
+		"DECIMAL", "NUMERIC", "DEC", "FIXED",
+		"FLOAT", "DOUBLE", "REAL", "DOUBLE PRECISION",
+		"BIT", "BOOL"
+	}
+
+	// Only want to do this for numeric field types; it can cause problems when done for strings and JSON
+	if asNumber.Contains(column_type.DatabaseTypeName) {
+		if govalidator.IsInt(raw) {
+			return escaped, nil
+		}
 	}
 
 	return fmt.Sprintf("'%s'", escaped), nil

--- a/internal/mysql/utils.go
+++ b/internal/mysql/utils.go
@@ -23,8 +23,7 @@ func getValue(raw string, column_type ColumnType) (string, error) {
 		"INTEGER", "INT", "SMALLINT", "TINYINT", "MEDIUMINT", "BIGINT",
 		"DECIMAL", "NUMERIC", "DEC", "FIXED",
 		"FLOAT", "DOUBLE", "REAL", "DOUBLE PRECISION",
-		"BIT", "BOOL"
-	}
+		"BIT", "BOOL" }
 
 	// Only want to do this for numeric field types; it can cause problems when done for strings and JSON
 	if asNumber.Contains(column_type.DatabaseTypeName) {

--- a/internal/mysql/utils.go
+++ b/internal/mysql/utils.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"slices"
+	"database/sql"
 
 	"github.com/asaskevich/govalidator"
 )
 
-func getValue(raw string, column_type ColumnType) (string, error) {
+func getValue(raw string, theColumnType ColumnType) (string, error) {
 	if raw == "" {
 		return "''", nil
 	}
@@ -26,7 +28,7 @@ func getValue(raw string, column_type ColumnType) (string, error) {
 		"BIT", "BOOL" }
 
 	// Only want to do this for numeric field types; it can cause problems when done for strings and JSON
-	if asNumber.Contains(column_type.DatabaseTypeName) {
+	if slices.Contains(asNumber, theColumnType.DatabaseTypeName) {
 		if govalidator.IsInt(raw) {
 			return escaped, nil
 		}

--- a/internal/mysql/utils_test.go
+++ b/internal/mysql/utils_test.go
@@ -7,15 +7,19 @@ import (
 )
 
 func TestGetValue(t *testing.T) {
-	val, err := getValue("")
+	val, err := getValue("", "TEXT")
 	assert.NoError(t, err)
 	assert.Equal(t, "''", val)
 
-	val, err = getValue("1")
+	val, err = getValue("1", "INTEGER")
 	assert.NoError(t, err)
 	assert.Equal(t, "1", val)
 
-	val, err = getValue("foo")
+	val, err = getValue("1", "TEXT")
+	assert.NoError(t, err)
+	assert.Equal(t, "'1'", val)
+
+	val, err = getValue("foo", "TEXT")
 	assert.NoError(t, err)
 	assert.Equal(t, "'foo'", val)
 }

--- a/internal/mysql/write.go
+++ b/internal/mysql/write.go
@@ -130,6 +130,9 @@ func (d *Client) WriteTableData(w io.Writer, table string, params provider.DumpP
 
 	// Get the column types
 	columntypes, err := rows.ColumnTypes()
+	if err != nil {
+		return err
+	}
 
 	// Set up and read the data, and print the INSERT statement
 	values := make([]*sql.RawBytes, len(columns))
@@ -173,7 +176,7 @@ func (d *Client) WriteTableData(w io.Writer, table string, params provider.DumpP
 			val := "NULL"
 
 			if col != nil {
-				val, err = getValue(string(*col), columntypes[columnindex])
+				val, err = getValue(string(*col), columntypes[columnindex].databaseType)
 				if err != nil {
 					return err
 				}

--- a/internal/mysql/write.go
+++ b/internal/mysql/write.go
@@ -176,7 +176,7 @@ func (d *Client) WriteTableData(w io.Writer, table string, params provider.DumpP
 			val := "NULL"
 
 			if col != nil {
-				val, err = getValue(string(*col), columntypes[columnindex].databaseType)
+				val, err = getValue(string(*col), columntypes[columnindex].DatabaseTypeName())
 				if err != nil {
 					return err
 				}

--- a/internal/mysql/write.go
+++ b/internal/mysql/write.go
@@ -176,7 +176,7 @@ func (d *Client) WriteTableData(w io.Writer, table string, params provider.DumpP
 			val := "NULL"
 
 			if col != nil {
-				val, err = getValue(string(*col), columntypes[columnindex].DatabaseTypeName())
+				val, err = getValue(string(*col), strings.ToUpper(columntypes[columnindex].DatabaseTypeName()))
 				if err != nil {
 					return err
 				}

--- a/internal/mysql/write.go
+++ b/internal/mysql/write.go
@@ -127,6 +127,11 @@ func (d *Client) WriteTableData(w io.Writer, table string, params provider.DumpP
 
 	defer rows.Close()
 
+
+	// Get the column types
+	columntypes := rows.ColumnTypes()
+
+	// Set up and read the data, and print the INSERT statement
 	values := make([]*sql.RawBytes, len(columns))
 	scanArgs := make([]interface{}, len(values))
 
@@ -164,11 +169,11 @@ func (d *Client) WriteTableData(w io.Writer, table string, params provider.DumpP
 
 		var vals []string
 
-		for _, col := range values {
+		for columnindex, col := range values {
 			val := "NULL"
 
 			if col != nil {
-				val, err = getValue(string(*col))
+				val, err = getValue(string(*col), columntypes[columnindex])
 				if err != nil {
 					return err
 				}

--- a/internal/mysql/write.go
+++ b/internal/mysql/write.go
@@ -129,7 +129,7 @@ func (d *Client) WriteTableData(w io.Writer, table string, params provider.DumpP
 
 
 	// Get the column types
-	columntypes := rows.ColumnTypes()
+	columntypes, err := rows.ColumnTypes()
 
 	// Set up and read the data, and print the INSERT statement
 	values := make([]*sql.RawBytes, len(columns))

--- a/internal/mysql/write_test.go
+++ b/internal/mysql/write_test.go
@@ -74,8 +74,8 @@ func TestMySQLDumpTableData(t *testing.T) {
 	assert.Nil(t, dumper.WriteTableData(buffer, "table", provider.DumpParams{
 		ExtendedInsertRows: 2}))
 
-	assert.Equal(t, strings.Count(buffer.String(), "INSERT INTO `table` VALUES"), 3)
-	assert.Equal(t, buffer.String(), "INSERT INTO `table` VALUES (1,'Go'),(2,'Java');\nINSERT INTO `table` VALUES (3,'C'),(4,'C++');\nINSERT INTO `table` VALUES (5,'Rust'),(6,'Closure');\n")
+	assert.Equal(t, 3, strings.Count(buffer.String(), "INSERT INTO `table` VALUES"))
+	assert.Equal(t, "INSERT INTO `table` VALUES ('1','Go'),('2','Java');\nINSERT INTO `table` VALUES ('3','C'),('4','C++');\nINSERT INTO `table` VALUES ('5','Rust'),('6','Closure');\n", buffer.String())
 }
 
 func TestMySQLDumpTableDataHandlingErrorFromSelectAllDataFor(t *testing.T) {


### PR DESCRIPTION
As per the issue writeup at https://github.com/skpr/mtk/issues/36 , the sanitiser was outputting unquoted numbers in the dump if the text was only a number, even if the field type wasn't a numeric type.  

This PR adds an additional check against the known Numeric types in MySQL.  If it's a known numeric type, it keeps the current behaviour, but if it's not (ie. if it's a TEXT, VARCHAR, or JSON type), it will still quote the number.  

This should result in fewer errors when trying to import a sanitised dump.