### PR TITLE
Adds --single-transaction

### DIFF
--- a/cmd/mtk/dump/command.go
+++ b/cmd/mtk/dump/command.go
@@ -1,6 +1,7 @@
 package dump
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -36,6 +37,7 @@ const cmdExample = `
 type Options struct {
 	ConfigFile         string
 	ExtendedInsertRows int
+	SingleTransaction  bool
 }
 
 // NewOptions will return a new Options.
@@ -71,7 +73,7 @@ func NewCommand(conn *mysql.Connection, provider, rdsRegion, rdsS3uri string) *c
 				panic(err)
 			}
 
-			if err := o.Run(os.Stdout, logger, conn, database, table, provider, rdsRegion, rdsS3uri, cfg); err != nil {
+			if err := o.Run(cmd.Context(), os.Stdout, logger, conn, database, table, provider, rdsRegion, rdsS3uri, cfg); err != nil {
 				panic(err)
 			}
 		},
@@ -79,13 +81,14 @@ func NewCommand(conn *mysql.Connection, provider, rdsRegion, rdsS3uri string) *c
 
 	cmd.Flags().StringVar(&o.ConfigFile, "config", envar.GetStringWithFallback("", envar.Config), "Path to the configuration file which contains the rules")
 	cmd.Flags().IntVar(&o.ExtendedInsertRows, "extended-insert-rows", envar.GetIntWithFallback(1000, envar.ExtendedInsertRows), "The number of rows to batch per INSERT statement")
+	cmd.Flags().BoolVar(&o.SingleTransaction, "single-transaction", true, "No changes that occur to InnoDB tables during the dump will be included in the dump")
 
 	return cmd
 }
 
 // Run will execute the dump command.
-func (o *Options) Run(w io.Writer, logger *log.Logger, conn *mysql.Connection, database, table, provider, region, uri string, cfg config.Rules) error {
-	db, err := conn.Open(database)
+func (o *Options) Run(ctx context.Context, w io.Writer, logger *log.Logger, conn *mysql.Connection, database, table, provider, region, uri string, cfg config.Rules) error {
+	db, err := conn.Open(ctx, database, o.SingleTransaction)
 	if err != nil {
 		return fmt.Errorf("failed to open database connection: %w", err)
 	}
@@ -95,21 +98,21 @@ func (o *Options) Run(w io.Writer, logger *log.Logger, conn *mysql.Connection, d
 	client := mysql.NewClient(db, logger, provider, region, uri)
 
 	if table != "" {
-		return o.runDumpTable(w, client, table, cfg)
+		return o.runDumpTable(ctx, w, client, table, cfg)
 	}
 
-	return o.runDumpTables(w, client, cfg)
+	return o.runDumpTables(ctx, w, client, cfg)
 }
 
-func (o *Options) runDumpTables(w io.Writer, client *mysql.Client, cfg config.Rules) error {
+func (o *Options) runDumpTables(ctx context.Context, w io.Writer, client *mysql.Client, cfg config.Rules) error {
 	// Get a list of tables to nodata, passed through a globber.
-	nodata, err := client.ListTablesByGlob(cfg.NoData)
+	nodata, err := client.ListTablesByGlob(ctx, cfg.NoData)
 	if err != nil {
 		return err
 	}
 
 	// Get a list of tables to ignore, passed through a globber.
-	ignore, err := client.ListTablesByGlob(cfg.Ignore)
+	ignore, err := client.ListTablesByGlob(ctx, cfg.Ignore)
 	if err != nil {
 		return err
 	}
@@ -138,7 +141,7 @@ func (o *Options) runDumpTables(w io.Writer, client *mysql.Client, cfg config.Ru
 	where := make(map[string]string, 0)
 
 	for glob, condition := range cfg.WhereMap() {
-		tables, err := client.ListTablesByGlob([]string{glob})
+		tables, err := client.ListTablesByGlob(ctx, []string{glob})
 		if err != nil {
 			return err
 		}
@@ -150,14 +153,14 @@ func (o *Options) runDumpTables(w io.Writer, client *mysql.Client, cfg config.Ru
 
 	params.WhereMap = where
 
-	return client.DumpTables(w, params)
+	return client.DumpTables(ctx, w, params)
 }
 
 // Helper function to dump a single table.
 // This function builds a list of DumpParams to that are specific to this table to avoid any performance bottlenecks.
 //
 //	eg. runDumpTables has to perform ListTablesByGlobal for each table, which is slow.
-func (o *Options) runDumpTable(w io.Writer, client *mysql.Client, table string, cfg config.Rules) error {
+func (o *Options) runDumpTable(ctx context.Context, w io.Writer, client *mysql.Client, table string, cfg config.Rules) error {
 	params := provider.DumpParams{
 		ExtendedInsertRows: o.ExtendedInsertRows,
 	}
@@ -216,5 +219,5 @@ func (o *Options) runDumpTable(w io.Writer, client *mysql.Client, table string, 
 		}
 	}
 
-	return client.DumpTable(w, table, params)
+	return client.DumpTable(ctx, w, table, params)
 }

--- a/cmd/mtk/main.go
+++ b/cmd/mtk/main.go
@@ -55,7 +55,6 @@ func init() {
 	cmd.PersistentFlags().StringVar(&conn.Password, "password", envar.GetStringWithFallback("", envar.Password, envar.MySQLPassword), "Password used to connect to MySQL instance")
 	cmd.PersistentFlags().StringVar(&conn.Protocol, "protocol", envar.GetStringWithFallback("tcp", envar.Protocol, envar.MySQLProtocol), "Connection protocol to use when connecting to MySQL instance")
 	cmd.PersistentFlags().Int32Var(&conn.Port, "port", int32(envar.GetIntWithFallback(3306, envar.Port, envar.MySQLPort)), "Port to connect to the MySQL instance on")
-	cmd.PersistentFlags().IntVar(&conn.MaxConn, "max-conn", envar.GetIntWithFallback(50, envar.MaxConn), "Sets the maximum number of open connections to the database")
 
 	cmd.PersistentFlags().StringVar(&providerName, "provider", envar.GetStringWithFallback("stdout", envar.Provider), "The provider to use (either 'stdout' or 'rds')")
 

--- a/cmd/mtk/table/list/command.go
+++ b/cmd/mtk/table/list/command.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -34,7 +35,8 @@ const cmdExample = `
 
 // Options is the commandline options for 'list' sub command
 type Options struct {
-	ConfigFile string
+	ConfigFile        string
+	SingleTransaction bool
 }
 
 // NewOptions returns a new Options struct.
@@ -61,7 +63,7 @@ func NewCommand(conn *mysql.Connection) *cobra.Command {
 			}
 
 			for _, database := range args {
-				if err := o.Run(logger, conn, database, cfg.Ignore); err != nil {
+				if err := o.Run(cmd.Context(), logger, conn, database, cfg.Ignore); err != nil {
 					return err
 				}
 			}
@@ -71,13 +73,14 @@ func NewCommand(conn *mysql.Connection) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&o.ConfigFile, "config", envar.GetStringWithFallback("", envar.Config), "Path to the configuration file which contains the rules")
+	cmd.Flags().BoolVar(&o.SingleTransaction, "single-transaction", true, "No changes that occur to InnoDB tables during the dump will be included in the dump")
 
 	return cmd
 }
 
 // Run the command which will list all tables.
-func (o *Options) Run(logger *log.Logger, conn *mysql.Connection, database string, exclude []string) error {
-	db, err := conn.Open(database)
+func (o *Options) Run(ctx context.Context, logger *log.Logger, conn *mysql.Connection, database string, exclude []string) error {
+	db, err := conn.Open(ctx, database, o.SingleTransaction)
 	if err != nil {
 		return fmt.Errorf("failed to open database connection: %w", err)
 	}
@@ -86,12 +89,12 @@ func (o *Options) Run(logger *log.Logger, conn *mysql.Connection, database strin
 
 	client := mysql.NewClient(db, logger, "", "", "")
 
-	tables, err := client.QueryTables()
+	tables, err := client.QueryTables(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list tables: %w", err)
 	}
 
-	skip, err := client.ListTablesByGlob(exclude)
+	skip, err := client.ListTablesByGlob(ctx, exclude)
 	if err != nil {
 		return fmt.Errorf("failed to list tables to skip: %w", err)
 	}

--- a/internal/mysql/mock/mock.go
+++ b/internal/mysql/mock/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -9,8 +10,10 @@ import (
 )
 
 // GetDB which can be used for testing purposes.
-func GetDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+func GetDB(t *testing.T) (*sql.Conn, sqlmock.Sqlmock) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
-	return db, mock
+	conn, err := db.Conn(context.TODO())
+	assert.Nil(t, err)
+	return conn, mock
 }

--- a/internal/mysql/mysql.go
+++ b/internal/mysql/mysql.go
@@ -26,7 +26,6 @@ type Connection struct {
 	Password string
 	Protocol string
 	Port     int32
-	MaxConn  int
 }
 
 // Open will Open a new database connection.

--- a/internal/mysql/mysql.go
+++ b/internal/mysql/mysql.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -29,7 +30,7 @@ type Connection struct {
 }
 
 // Open will Open a new database connection.
-func (o Connection) Open(database string) (*sql.DB, error) {
+func (o Connection) Open(ctx context.Context, database string, singleTransaction bool) (*sql.Conn, error) {
 	cfg := mysql.Config{
 		User:                 o.Username,
 		Passwd:               o.Password,
@@ -44,14 +45,27 @@ func (o Connection) Open(database string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	db.SetMaxOpenConns(o.MaxConn)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	return db, nil
+	// Match mysqldump --single-transaction behavior (REPEATABLE READ + consistent snapshot, read-only).
+	if singleTransaction {
+		if _, err := conn.ExecContext(ctx, "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ"); err != nil {
+			log.Fatal(err)
+		}
+		if _, err := conn.ExecContext(ctx, "START TRANSACTION WITH CONSISTENT SNAPSHOT, READ ONLY"); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	return conn, nil
 }
 
 // Client used for dumping a database and/or table.
 type Client struct {
-	DB     *sql.DB
+	Conn   *sql.Conn
 	Logger *log.Logger
 
 	// A field for caching a list of tables for this database.
@@ -66,9 +80,9 @@ type Client struct {
 }
 
 // NewClient for dumping a full or single table from a database.
-func NewClient(db *sql.DB, logger *log.Logger, provider, region, uri string) *Client {
+func NewClient(conn *sql.Conn, logger *log.Logger, provider, region, uri string) *Client {
 	return &Client{
-		DB:       db,
+		Conn:     conn,
 		Logger:   logger,
 		Provider: provider,
 		Region:   region,
@@ -77,12 +91,12 @@ func NewClient(db *sql.DB, logger *log.Logger, provider, region, uri string) *Cl
 }
 
 // DumpTables will write all table data to a single writer.
-func (d *Client) DumpTables(w io.Writer, params provider.DumpParams) error {
+func (d *Client) DumpTables(ctx context.Context, w io.Writer, params provider.DumpParams) error {
 	if err := d.WriteHeader(w); err != nil {
 		return fmt.Errorf("failed to write header: %w", err)
 	}
 
-	if err := d.writeTables(w, params); err != nil {
+	if err := d.writeTables(ctx, w, params); err != nil {
 		return fmt.Errorf("failed to write tables: %w", err)
 	}
 
@@ -98,12 +112,12 @@ func (d *Client) DumpTables(w io.Writer, params provider.DumpParams) error {
 }
 
 // DumpTable is convenient if you wish to coordinate a dump eg. Single file per table.
-func (d *Client) DumpTable(w io.Writer, table string, params provider.DumpParams) error {
+func (d *Client) DumpTable(ctx context.Context, w io.Writer, table string, params provider.DumpParams) error {
 	if err := d.WriteHeader(w); err != nil {
 		return fmt.Errorf("failed to write header: %w", err)
 	}
 
-	if err := d.writeTable(w, table, params); err != nil {
+	if err := d.writeTable(ctx, w, table, params); err != nil {
 		return fmt.Errorf("failed to write tables: %w", err)
 	}
 

--- a/internal/mysql/provider/provider.go
+++ b/internal/mysql/provider/provider.go
@@ -1,8 +1,10 @@
 package provider
 
+import "context"
+
 // Interface implements the required functionality for a Provider.
 type Interface interface {
-	GetSelectQueryForTable(table string, params DumpParams) (string, error)
+	GetSelectQueryForTable(ctx context.Context, table string, params DumpParams) (string, error)
 }
 
 // DumpParams is used to pass parameters to the Dump function.

--- a/internal/mysql/provider/rds/provider.go
+++ b/internal/mysql/provider/rds/provider.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -13,7 +14,7 @@ import (
 // Client used for dumping a database and/or table.
 type Client struct {
 	provider.Interface
-	DB     *sql.DB
+	Conn   *sql.Conn
 	Logger *log.Logger
 
 	Region string // Region configuration
@@ -21,9 +22,9 @@ type Client struct {
 }
 
 // NewClient for dumping a full or single table from a database.
-func NewClient(db *sql.DB, logger *log.Logger, region, uri string) *Client {
+func NewClient(conn *sql.Conn, logger *log.Logger, region, uri string) *Client {
 	return &Client{
-		DB:     db,
+		Conn:   conn,
 		Logger: logger,
 		Region: region,
 		URI:    uri,
@@ -31,8 +32,8 @@ func NewClient(db *sql.DB, logger *log.Logger, region, uri string) *Client {
 }
 
 // GetSelectQueryForTable will return a complete SELECT query to export data from a table.
-func (d *Client) GetSelectQueryForTable(table string, params provider.DumpParams) (string, error) {
-	cols, err := providerutils.QueryColumnsForTable(d.DB, table, params)
+func (d *Client) GetSelectQueryForTable(ctx context.Context, table string, params provider.DumpParams) (string, error) {
+	cols, err := providerutils.QueryColumnsForTable(ctx, d.Conn, table, params)
 	if err != nil {
 		return "", err
 	}

--- a/internal/mysql/provider/rds/provider_test.go
+++ b/internal/mysql/provider/rds/provider_test.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"context"
 	"log"
 	"os"
 	"testing"
@@ -17,7 +18,7 @@ func TestMySQLGetExportSelectQueryFor(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "ap-southheast-2", "s3://path/to/bucket")
 	mock.ExpectQuery("SELECT \\* FROM `table` LIMIT 1").WillReturnRows(
 		sqlmock.NewRows([]string{"c1", "c2"}).AddRow("a", "b"))
-	query, err := dumper.GetSelectQueryForTable("table", provider.DumpParams{
+	query, err := dumper.GetSelectQueryForTable(context.TODO(), "table", provider.DumpParams{
 		SelectMap: map[string]map[string]string{"table": {"c2": "NOW()"}},
 		WhereMap:  map[string]string{"table": "c1 > 0"},
 	})

--- a/internal/mysql/provider/stdout/provider.go
+++ b/internal/mysql/provider/stdout/provider.go
@@ -1,6 +1,7 @@
 package stdout
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -13,21 +14,21 @@ import (
 // Client used for dumping a database and/or table.
 type Client struct {
 	provider.Interface
-	DB     *sql.DB
+	Conn   *sql.Conn
 	Logger *log.Logger
 }
 
 // NewClient for dumping a full or single table from a database.
-func NewClient(db *sql.DB, logger *log.Logger) *Client {
+func NewClient(conn *sql.Conn, logger *log.Logger) *Client {
 	return &Client{
-		DB:     db,
+		Conn:   conn,
 		Logger: logger,
 	}
 }
 
 // GetSelectQueryForTable will return a complete SELECT query to fetch data from a table.
-func (d *Client) GetSelectQueryForTable(table string, params provider.DumpParams) (string, error) {
-	cols, err := providerutils.QueryColumnsForTable(d.DB, table, params)
+func (d *Client) GetSelectQueryForTable(ctx context.Context, table string, params provider.DumpParams) (string, error) {
+	cols, err := providerutils.QueryColumnsForTable(ctx, d.Conn, table, params)
 	if err != nil {
 		return "", err
 	}

--- a/internal/mysql/provider/stdout/provider_test.go
+++ b/internal/mysql/provider/stdout/provider_test.go
@@ -1,6 +1,7 @@
 package stdout
 
 import (
+	"context"
 	"errors"
 	"log"
 	"os"
@@ -18,7 +19,7 @@ func TestMySQLGetSelectQueryFor(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0))
 	mock.ExpectQuery("SELECT \\* FROM `table` LIMIT 1").WillReturnRows(
 		sqlmock.NewRows([]string{"c1", "c2"}).AddRow("a", "b"))
-	query, err := dumper.GetSelectQueryForTable("table", provider.DumpParams{
+	query, err := dumper.GetSelectQueryForTable(context.TODO(), "table", provider.DumpParams{
 		SelectMap: map[string]map[string]string{"table": {"c2": "NOW()"}},
 		WhereMap:  map[string]string{"table": "c1 > 0"},
 	})
@@ -31,7 +32,7 @@ func TestMySQLGetSelectQueryForHandlingError(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0))
 	e := errors.New("broken")
 	mock.ExpectQuery("SELECT \\* FROM `table` LIMIT 1").WillReturnError(e)
-	query, err := dumper.GetSelectQueryForTable("table", provider.DumpParams{
+	query, err := dumper.GetSelectQueryForTable(context.TODO(), "table", provider.DumpParams{
 		SelectMap: map[string]map[string]string{"table": {"c2": "NOW()"}},
 		WhereMap:  map[string]string{"table": "c1 > 0"},
 	})

--- a/internal/mysql/provider/utils/utils.go
+++ b/internal/mysql/provider/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -9,10 +10,10 @@ import (
 )
 
 // QueryColumnsForTable for a given table.
-func QueryColumnsForTable(database *sql.DB, table string, params provider.DumpParams) ([]string, error) {
+func QueryColumnsForTable(ctx context.Context, conn *sql.Conn, table string, params provider.DumpParams) ([]string, error) {
 	var rows *sql.Rows
 
-	rows, err := database.Query(fmt.Sprintf("SELECT * FROM `%s` LIMIT 1", table))
+	rows, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM `%s` LIMIT 1", table))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mysql/provider/utils/utils_test.go
+++ b/internal/mysql/provider/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -15,7 +16,7 @@ func TestMySQLGetColumnsForSelect(t *testing.T) {
 	db, mock := mock.GetDB(t)
 	mock.ExpectQuery("SELECT \\* FROM `table` LIMIT 1").WillReturnRows(
 		sqlmock.NewRows([]string{"col1", "col2", "col3"}).AddRow("a", "b", "c"))
-	columns, err := QueryColumnsForTable(db, "table", provider.DumpParams{
+	columns, err := QueryColumnsForTable(context.TODO(), db, "table", provider.DumpParams{
 		SelectMap: map[string]map[string]string{"table": {"col2": "NOW()"}},
 	})
 	assert.Nil(t, err)
@@ -26,7 +27,7 @@ func TestMySQLGetColumnsForSelectHandlingErrorWhenQuerying(t *testing.T) {
 	db, mock := mock.GetDB(t)
 	e := errors.New("broken")
 	mock.ExpectQuery("SELECT \\* FROM `table` LIMIT 1").WillReturnError(e)
-	columns, err := QueryColumnsForTable(db, "table", provider.DumpParams{
+	columns, err := QueryColumnsForTable(context.TODO(), db, "table", provider.DumpParams{
 		SelectMap: map[string]map[string]string{"table": {"col2": "NOW()"}},
 	})
 	assert.Equal(t, err, e)

--- a/internal/mysql/tables.go
+++ b/internal/mysql/tables.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -15,10 +16,10 @@ import (
 )
 
 // ListTablesByGlob will return a list of tables based on a list of globs.
-func (d *Client) ListTablesByGlob(globs []string) ([]string, error) {
+func (d *Client) ListTablesByGlob(ctx context.Context, globs []string) ([]string, error) {
 	var globbed []string
 
-	tables, err := d.QueryTables()
+	tables, err := d.QueryTables(ctx)
 	if err != nil {
 		return globbed, fmt.Errorf("failed to query for tables: %w", err)
 	}
@@ -37,7 +38,7 @@ func (d *Client) ListTablesByGlob(globs []string) ([]string, error) {
 }
 
 // QueryTables will return a list of tables.
-func (d *Client) QueryTables() ([]string, error) {
+func (d *Client) QueryTables(ctx context.Context) ([]string, error) {
 	// Use the cached tables if we have them.
 	if len(d.cachedTables) > 0 {
 		return d.cachedTables, nil
@@ -45,7 +46,7 @@ func (d *Client) QueryTables() ([]string, error) {
 
 	tables := make([]string, 0)
 
-	rows, err := d.DB.Query("SHOW FULL TABLES")
+	rows, err := d.Conn.QueryContext(ctx, "SHOW FULL TABLES")
 	if err != nil {
 		return tables, err
 	}
@@ -74,29 +75,29 @@ func (d *Client) QueryTables() ([]string, error) {
 func (d *Client) getProviderClient() (provider.Interface, error) {
 	switch d.Provider {
 	case "rds":
-		client := rds.NewClient(d.DB, d.Logger, d.Region, d.URI)
+		client := rds.NewClient(d.Conn, d.Logger, d.Region, d.URI)
 		return client, nil
 	case "stdout":
-		return stdout.NewClient(d.DB, d.Logger), nil
+		return stdout.NewClient(d.Conn, d.Logger), nil
 	default:
 		return nil, errors.New("invalid provider")
 	}
 }
 
 // Helper function to get all data for a table.
-func (d *Client) selectAllDataForTable(table string, params provider.DumpParams) (*sql.Rows, []string, error) {
+func (d *Client) selectAllDataForTable(ctx context.Context, table string, params provider.DumpParams) (*sql.Rows, []string, error) {
 
 	client, err := d.getProviderClient()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	query, err := client.GetSelectQueryForTable(table, params)
+	query, err := client.GetSelectQueryForTable(ctx, table, params)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	rows, err := d.DB.Query(query)
+	rows, err := d.Conn.QueryContext(ctx, query)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,14 +111,14 @@ func (d *Client) selectAllDataForTable(table string, params provider.DumpParams)
 }
 
 // GetRowCountForTable will return the number of rows using a SELECT statement.
-func (d *Client) GetRowCountForTable(table string, params provider.DumpParams) (uint64, error) {
+func (d *Client) GetRowCountForTable(ctx context.Context, table string, params provider.DumpParams) (uint64, error) {
 	query := fmt.Sprintf("SELECT COUNT(*) FROM `%s`", table)
 
 	if where, ok := params.WhereMap[strings.ToLower(table)]; ok {
 		query = fmt.Sprintf("%s WHERE %s", query, where)
 	}
 
-	row := d.DB.QueryRow(query)
+	row := d.Conn.QueryRowContext(ctx, query)
 
 	var count uint64
 
@@ -129,16 +130,16 @@ func (d *Client) GetRowCountForTable(table string, params provider.DumpParams) (
 }
 
 // LockTableReading explicitly acquires table locks for the current client session.
-func (d *Client) LockTableReading(table string) (sql.Result, error) {
-	return d.DB.Exec(fmt.Sprintf("LOCK TABLES `%s` READ", table))
+func (d *Client) LockTableReading(ctx context.Context, table string) (sql.Result, error) {
+	return d.Conn.ExecContext(ctx, fmt.Sprintf("LOCK TABLES `%s` READ", table))
 }
 
 // UnlockTables explicitly releases any table locks held by the current session.
-func (d *Client) UnlockTables() (sql.Result, error) {
-	return d.DB.Exec("UNLOCK TABLES")
+func (d *Client) UnlockTables(ctx context.Context) (sql.Result, error) {
+	return d.Conn.ExecContext(ctx, "UNLOCK TABLES")
 }
 
 // FlushTable will force a tables to be closed.
-func (d *Client) FlushTable(table string) (sql.Result, error) {
-	return d.DB.Exec(fmt.Sprintf("FLUSH TABLES `%s`", table))
+func (d *Client) FlushTable(ctx context.Context, table string) (sql.Result, error) {
+	return d.Conn.ExecContext(ctx, fmt.Sprintf("FLUSH TABLES `%s`", table))
 }

--- a/internal/mysql/tables_test.go
+++ b/internal/mysql/tables_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"log"
 	"os"
@@ -18,7 +19,7 @@ func TestMySQLFlushTable(t *testing.T) {
 	db, mock := mock.GetDB(t)
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "", "", "")
 	mock.ExpectExec("FLUSH TABLES `table`").WillReturnResult(sqlmock.NewResult(0, 1))
-	_, err := dumper.FlushTable("table")
+	_, err := dumper.FlushTable(context.TODO(), "table")
 	assert.Nil(t, err)
 }
 
@@ -26,7 +27,7 @@ func TestMySQLUnlockTables(t *testing.T) {
 	db, mock := mock.GetDB(t)
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "", "", "")
 	mock.ExpectExec("UNLOCK TABLES").WillReturnResult(sqlmock.NewResult(0, 1))
-	_, err := dumper.UnlockTables()
+	_, err := dumper.UnlockTables(context.TODO())
 	assert.Nil(t, err)
 }
 
@@ -38,7 +39,7 @@ func TestMySQLQueryTables(t *testing.T) {
 			AddRow("table1", "BASE TABLE").
 			AddRow("table2", "BASE TABLE"),
 	)
-	tables, err := dumper.QueryTables()
+	tables, err := dumper.QueryTables(context.TODO())
 	assert.Equal(t, []string{"table1", "table2"}, tables)
 	assert.Nil(t, err)
 }
@@ -47,7 +48,7 @@ func TestMySQLLockTableRead(t *testing.T) {
 	db, mock := mock.GetDB(t)
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "", "", "")
 	mock.ExpectExec("LOCK TABLES `table` READ").WillReturnResult(sqlmock.NewResult(0, 1))
-	_, err := dumper.LockTableReading("table")
+	_, err := dumper.LockTableReading(context.TODO(), "table")
 	assert.Nil(t, err)
 }
 
@@ -56,7 +57,7 @@ func TestMySQLGetTablesHandlingErrorWhenListingTables(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "", "", "")
 	expectedErr := errors.New("broken")
 	mock.ExpectQuery("SHOW FULL TABLES").WillReturnError(expectedErr)
-	tables, err := dumper.QueryTables()
+	tables, err := dumper.QueryTables(context.TODO())
 	assert.Equal(t, []string{}, tables)
 	assert.Equal(t, expectedErr, err)
 }
@@ -66,7 +67,7 @@ func TestMySQLGetTablesHandlingErrorWhenScanningRow(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "", "", "")
 	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
 		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).AddRow(1, nil))
-	tables, err := dumper.QueryTables()
+	tables, err := dumper.QueryTables(context.TODO())
 	assert.Equal(t, []string{}, tables)
 	assert.NotNil(t, err)
 }
@@ -84,7 +85,7 @@ func TestMySQLDumpCreateTable(t *testing.T) {
 			AddRow("table", ddl),
 	)
 	buffer := bytes.NewBuffer(make([]byte, 0))
-	assert.Nil(t, dumper.WriteCreateTable(buffer, "table"))
+	assert.Nil(t, dumper.WriteCreateTable(context.TODO(), buffer, "table"))
 	assert.Contains(t, buffer.String(), "DROP TABLE IF EXISTS `table`")
 	assert.Contains(t, buffer.String(), ddl)
 }
@@ -95,7 +96,7 @@ func TestMySQLDumpCreateTableHandlingErrorWhenScanningRows(t *testing.T) {
 	mock.ExpectQuery("SHOW CREATE TABLE `table`").WillReturnRows(
 		sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("table", nil))
 	buffer := bytes.NewBuffer(make([]byte, 0))
-	assert.NotNil(t, dumper.WriteCreateTable(buffer, "table"))
+	assert.NotNil(t, dumper.WriteCreateTable(context.TODO(), buffer, "table"))
 }
 
 func TestMySQLGetRowCount(t *testing.T) {
@@ -103,7 +104,7 @@ func TestMySQLGetRowCount(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "", "", "")
 	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM `table` WHERE c1 > 0").WillReturnRows(
 		sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(1234))
-	count, err := dumper.GetRowCountForTable("table", provider.DumpParams{
+	count, err := dumper.GetRowCountForTable(context.TODO(), "table", provider.DumpParams{
 		WhereMap: map[string]string{"table": "c1 > 0"},
 	})
 	assert.Nil(t, err)
@@ -115,7 +116,7 @@ func TestMySQLGetRowCountHandlingError(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "", "", "")
 	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM `table` WHERE c1 > 0").WillReturnRows(
 		sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(nil))
-	count, err := dumper.GetRowCountForTable("table", provider.DumpParams{
+	count, err := dumper.GetRowCountForTable(context.TODO(), "table", provider.DumpParams{
 		WhereMap: map[string]string{"table": "c1 > 0"},
 	})
 	assert.NotNil(t, err)

--- a/internal/mysql/write.go
+++ b/internal/mysql/write.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io"
@@ -78,7 +79,7 @@ func (d *Client) WriteUnlockTables(w io.Writer) {
 }
 
 // WriteCreateTable script used when dumping a database.
-func (d *Client) WriteCreateTable(w io.Writer, table string) error {
+func (d *Client) WriteCreateTable(ctx context.Context, w io.Writer, table string) error {
 	d.Logger.Println("Dumping structure for table:", table)
 
 	fmt.Fprintf(w, "\n--\n-- Structure for table `%s`\n--\n\n", table)
@@ -87,7 +88,7 @@ func (d *Client) WriteCreateTable(w io.Writer, table string) error {
 	fmt.Fprintln(w, "/*!40101 SET @saved_cs_client     = @@character_set_client */;")
 	fmt.Fprintln(w, "/*!40101 SET character_set_client = utf8 */;")
 
-	row := d.DB.QueryRow(fmt.Sprintf("SHOW CREATE TABLE `%s`", table))
+	row := d.Conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE TABLE `%s`", table))
 
 	var name, ddl string
 
@@ -103,10 +104,10 @@ func (d *Client) WriteCreateTable(w io.Writer, table string) error {
 }
 
 // WriteTableHeader which contains debug information.
-func (d *Client) WriteTableHeader(w io.Writer, table string, params provider.DumpParams) (uint64, error) {
+func (d *Client) WriteTableHeader(ctx context.Context, w io.Writer, table string, params provider.DumpParams) (uint64, error) {
 	fmt.Fprintf(w, "\n--\n-- Data for table `%s`", table)
 
-	count, err := d.GetRowCountForTable(table, params)
+	count, err := d.GetRowCountForTable(ctx, table, params)
 	if err != nil {
 		return 0, err
 	}
@@ -117,10 +118,10 @@ func (d *Client) WriteTableHeader(w io.Writer, table string, params provider.Dum
 }
 
 // WriteTableData for a specific table.
-func (d *Client) WriteTableData(w io.Writer, table string, params provider.DumpParams) error {
+func (d *Client) WriteTableData(ctx context.Context, w io.Writer, table string, params provider.DumpParams) error {
 	d.Logger.Println("Dumping data for table:", table)
 
-	rows, columns, err := d.selectAllDataForTable(table, params)
+	rows, columns, err := d.selectAllDataForTable(ctx, table, params)
 	if err != nil {
 		return err
 	}
@@ -186,14 +187,14 @@ func (d *Client) WriteTableData(w io.Writer, table string, params provider.DumpP
 }
 
 // WriteTables will create a script for all tables.
-func (d *Client) writeTables(w io.Writer, params provider.DumpParams) error {
-	tables, err := d.QueryTables()
+func (d *Client) writeTables(ctx context.Context, w io.Writer, params provider.DumpParams) error {
+	tables, err := d.QueryTables(ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, table := range tables {
-		if err := d.writeTable(w, table, params); err != nil {
+		if err := d.writeTable(ctx, w, table, params); err != nil {
 			return err
 		}
 	}
@@ -202,23 +203,23 @@ func (d *Client) writeTables(w io.Writer, params provider.DumpParams) error {
 }
 
 // WriteTable allows for a single table dump script.
-func (d *Client) writeTable(w io.Writer, table string, params provider.DumpParams) error {
+func (d *Client) writeTable(ctx context.Context, w io.Writer, table string, params provider.DumpParams) error {
 	if params.FilterMap[strings.ToLower(table)] == OperationIgnore {
 		return nil
 	}
 
 	skipData := params.FilterMap[strings.ToLower(table)] == OperationNoData
 	if !skipData && params.UseTableLock {
-		if _, err := d.LockTableReading(table); err != nil {
+		if _, err := d.LockTableReading(ctx, table); err != nil {
 			return err
 		}
 
-		if _, err := d.FlushTable(table); err != nil {
+		if _, err := d.FlushTable(ctx, table); err != nil {
 			return err
 		}
 	}
 
-	if err := d.WriteCreateTable(w, table); err != nil {
+	if err := d.WriteCreateTable(ctx, w, table); err != nil {
 		return err
 	}
 
@@ -226,7 +227,7 @@ func (d *Client) writeTable(w io.Writer, table string, params provider.DumpParam
 		return nil
 	}
 
-	cnt, err := d.WriteTableHeader(w, table, params)
+	cnt, err := d.WriteTableHeader(ctx, w, table, params)
 	if err != nil {
 		return err
 	}
@@ -239,7 +240,7 @@ func (d *Client) writeTable(w io.Writer, table string, params provider.DumpParam
 	d.WriteTableDisableKeys(w, table)
 	d.WriteAutoCommitOff(w)
 
-	if err := d.WriteTableData(w, table, params); err != nil {
+	if err := d.WriteTableData(ctx, w, table, params); err != nil {
 		return fmt.Errorf("failed to write table data: %w", err)
 	}
 

--- a/internal/mysql/write_test.go
+++ b/internal/mysql/write_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"log"
 	"os"
@@ -21,7 +22,7 @@ func TestMySQLDumpTableHeader(t *testing.T) {
 	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM `table`").WillReturnRows(
 		sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(1234))
 	buffer := bytes.NewBuffer(make([]byte, 0))
-	count, err := dumper.WriteTableHeader(buffer, "table", provider.DumpParams{})
+	count, err := dumper.WriteTableHeader(context.TODO(), buffer, "table", provider.DumpParams{})
 	assert.Equal(t, uint64(1234), count)
 	assert.Nil(t, err)
 	assert.Contains(t, buffer.String(), "Data for table `table`")
@@ -34,7 +35,7 @@ func TestMySQLDumpTableHeaderHandlingError(t *testing.T) {
 	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM `table`").WillReturnRows(
 		sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(nil))
 	buffer := bytes.NewBuffer(make([]byte, 0))
-	count, err := dumper.WriteTableHeader(buffer, "table", provider.DumpParams{})
+	count, err := dumper.WriteTableHeader(context.TODO(), buffer, "table", provider.DumpParams{})
 	assert.Equal(t, uint64(0), count)
 	assert.NotNil(t, err)
 }
@@ -71,7 +72,7 @@ func TestMySQLDumpTableData(t *testing.T) {
 			AddRow(5, "Rust").
 			AddRow(6, "Closure"))
 
-	assert.Nil(t, dumper.WriteTableData(buffer, "table", provider.DumpParams{
+	assert.Nil(t, dumper.WriteTableData(context.TODO(), buffer, "table", provider.DumpParams{
 		ExtendedInsertRows: 2}))
 
 	assert.Equal(t, strings.Count(buffer.String(), "INSERT INTO `table` VALUES"), 3)
@@ -84,5 +85,5 @@ func TestMySQLDumpTableDataHandlingErrorFromSelectAllDataFor(t *testing.T) {
 	dumper := NewClient(db, log.New(os.Stdout, "", 0), "stdout", "", "")
 	e := errors.New("fail")
 	mock.ExpectQuery("SELECT \\* FROM `table` LIMIT 1").WillReturnError(e)
-	assert.Equal(t, e, dumper.WriteTableData(buffer, "table", provider.DumpParams{}))
+	assert.Equal(t, e, dumper.WriteTableData(context.TODO(), buffer, "table", provider.DumpParams{}))
 }

--- a/revive.toml
+++ b/revive.toml
@@ -13,7 +13,6 @@ warningCode = 0
 [rule.error-naming]
 [rule.exported]
 [rule.increment-decrement]
-[rule.var-naming]
 [rule.var-declaration]
 [rule.range]
 [rule.receiver-naming]
@@ -28,5 +27,6 @@ warningCode = 0
 
 # These should be uncommented and resolve in
 # future pull requests.
+# [rule.var-naming]
 # [rule.package-comments]
 # [rule.unused-parameter]


### PR DESCRIPTION
**Overview**

Mimic the functionality of `mysqldump --single-transaction`

https://mysqldump.guru/mysqldump-single-transaction-flag.html

**Solution**

* Swap to a single connection
* This required context to be handed throughout the application
* Removes max connections single we are doing a single connection