### PR TITLE
New command: dump-tables

### DIFF
--- a/cmd/mtk/dump-tables/command.go
+++ b/cmd/mtk/dump-tables/command.go
@@ -1,0 +1,119 @@
+package dumptables
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/skpr/mtk/cmd/mtk/dump"
+	"github.com/skpr/mtk/internal/mysql"
+	"github.com/skpr/mtk/pkg/config"
+	"github.com/skpr/mtk/pkg/envar"
+)
+
+const cmdLong = `
+  Dumps a sanitized output of a MySQL database into a directory, with one file created per table`
+
+const cmdExample = `
+  export MTK_HOSTNAME=localhost
+  export MTK_USERNAME=test
+  export MTK_PASSWORD=test
+
+  # Dump all database tables.
+  mtk dump-tables <database> <directory>
+
+  # Dump all database tables using config file
+  mtk dump-tables <database> --config <config file> <directory>`
+
+// Options is the commandline options for 'dump' sub command
+type Options struct {
+	ConfigFile         string
+	ExtendedInsertRows int
+	SingleTransaction  bool
+}
+
+// NewOptions will return a new Options.
+func NewOptions() Options {
+	return Options{}
+}
+
+// NewCommand will return a new Cobra command.
+func NewCommand(conn *mysql.Connection, provider, rdsRegion, rdsS3uri string) *cobra.Command {
+	o := NewOptions()
+
+	cmd := &cobra.Command{
+		Use:                   "dump-tables",
+		DisableFlagsInUseLine: true,
+		Short:                 "Dumps a sanitized output of a MySQL database into a directory.",
+		Args:                  cobra.ExactArgs(2),
+		Long:                  cmdLong,
+		Example:               cmdExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var (
+				database  = args[0]
+				directory = args[1]
+			)
+
+			if _, err := os.Stat(directory); os.IsNotExist(err) {
+				// Fail if directory does not exist
+				return fmt.Errorf("directory does not exist: %s", directory)
+			}
+
+			logger := log.New(os.Stderr, "", 0)
+
+			cfg, err := config.Load(o.ConfigFile)
+			if err != nil {
+				return fmt.Errorf("failed to load config file: %w", err)
+			}
+
+			return o.Run(cmd.Context(), os.Stdout, logger, conn, database, directory, provider, rdsRegion, rdsS3uri, cfg)
+		},
+	}
+
+	cmd.Flags().StringVar(&o.ConfigFile, "config", envar.GetStringWithFallback("", envar.Config), "Path to the configuration file which contains the rules")
+	cmd.Flags().IntVar(&o.ExtendedInsertRows, "extended-insert-rows", envar.GetIntWithFallback(1000, envar.ExtendedInsertRows), "The number of rows to batch per INSERT statement")
+	cmd.Flags().BoolVar(&o.SingleTransaction, "single-transaction", true, "No changes that occur to InnoDB tables during the dump will be included in the dump")
+
+	return cmd
+}
+
+// Run will execute the dump command.
+func (o *Options) Run(ctx context.Context, w io.Writer, logger *log.Logger, conn *mysql.Connection, database, directory, provider, region, uri string, cfg config.Rules) error {
+	db, err := conn.Open(ctx, database, o.SingleTransaction)
+	if err != nil {
+		return fmt.Errorf("failed to open database connection: %w", err)
+	}
+
+	defer db.Close()
+
+	client := mysql.NewClient(db, logger, provider, region, uri)
+
+	return o.runDumpTables(ctx, w, directory, client, cfg)
+}
+
+// Helper function to dump all tables in a database.
+func (o *Options) runDumpTables(ctx context.Context, w io.Writer, directory string, client *mysql.Client, cfg config.Rules) error {
+	tables, err := client.QueryTables(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list tables: %w", err)
+	}
+
+	for _, table := range tables {
+		// Write to a specific file.
+		file, err := os.Create(fmt.Sprintf("%s/%s.sql", directory, table))
+		if err != nil {
+			return fmt.Errorf("failed to create file for table %q: %w", table, err)
+		}
+		defer file.Close()
+
+		if err := dump.RunDumpTable(ctx, file, client, table, o.ExtendedInsertRows, cfg); err != nil {
+			return fmt.Errorf("failed to dump table %q: %w", table, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/mtk/dump/command.go
+++ b/cmd/mtk/dump/command.go
@@ -98,7 +98,7 @@ func (o *Options) Run(ctx context.Context, w io.Writer, logger *log.Logger, conn
 	client := mysql.NewClient(db, logger, provider, region, uri)
 
 	if table != "" {
-		return o.runDumpTable(ctx, w, client, table, cfg)
+		return RunDumpTable(ctx, w, client, table, o.ExtendedInsertRows, cfg)
 	}
 
 	return o.runDumpTables(ctx, w, client, cfg)
@@ -160,9 +160,9 @@ func (o *Options) runDumpTables(ctx context.Context, w io.Writer, client *mysql.
 // This function builds a list of DumpParams to that are specific to this table to avoid any performance bottlenecks.
 //
 //	eg. runDumpTables has to perform ListTablesByGlobal for each table, which is slow.
-func (o *Options) runDumpTable(ctx context.Context, w io.Writer, client *mysql.Client, table string, cfg config.Rules) error {
+func RunDumpTable(ctx context.Context, w io.Writer, client *mysql.Client, table string, extendedInsertRows int, cfg config.Rules) error {
 	params := provider.DumpParams{
-		ExtendedInsertRows: o.ExtendedInsertRows,
+		ExtendedInsertRows: extendedInsertRows,
 	}
 
 	// If this table matches an ignore glob, then skip it.

--- a/cmd/mtk/main.go
+++ b/cmd/mtk/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/skpr/mtk/cmd/mtk/dump"
+	dumptables "github.com/skpr/mtk/cmd/mtk/dump-tables"
 	"github.com/skpr/mtk/cmd/mtk/table"
 	"github.com/skpr/mtk/internal/mysql"
 	"github.com/skpr/mtk/pkg/envar"
@@ -79,6 +80,7 @@ func main() {
 	cmd.SetUsageTemplate(usageTemplate)
 
 	cmd.AddCommand(dump.NewCommand(conn, providerName, rdsRegion, rdsS3Uri))
+	cmd.AddCommand(dumptables.NewCommand(conn, providerName, rdsRegion, rdsS3Uri))
 	cmd.AddCommand(table.NewCommand(conn))
 
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
**Overview**

Adds a command which dumps tables in a directory. One file per table.

This is all contained in the one command so we still keep the consistency guarantees from the PR below:

https://github.com/skpr/mtk/pull/38

**Usage**

```
mtk dump-tables <database> <directory>
```